### PR TITLE
feat:  added dropdown error border and fixed button height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
-## 2.1.8
+## 2.1.9
 
-- DropDownInput title style changed to bodyText2
+- Added `isMandatory` param to `DropDownInput`. If it is set to `true`,
+  and `TextEditingController.text` value is empty the border color is set to the current theme's
+  `errorColor` (default: `false`)
+- [Breaking change] Added limit of standard `BasfButton` height
 
 <details >
 <summary>Previous versions</summary>
 
+## 2.1.8
+
+- `DropDownInput` title style changed to `bodyText2`
+
 ## 2.1.7
 
-- TextInput title style changed to bodyText2
+- `TextInput` title style changed to `bodyText2`
 
 ## 2.1.6
 

--- a/coverage_badge.svg
+++ b/coverage_badge.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="20">
+<svg height="20" width="102" xmlns="http://www.w3.org/2000/svg">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
         <stop offset="1" stop-opacity=".1" />
@@ -11,10 +11,15 @@
         <path fill="#44cc11" d="M59 0h43v20H59z" />
         <path fill="url(#b)" d="M0 0h102v20H0z" />
     </g>
-    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
-        <text x="305" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="490">coverage</text>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif"
+        font-size="110">
+        <text x="305" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)"
+            textLength="490">coverage
+        </text>
         <text x="305" y="140" transform="scale(.1)" textLength="490">coverage</text>
-        <text x="795" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">77.3%</text>
-        <text x="795" y="140" transform="scale(.1)" textLength="330">77.3%</text>
+        <text fill="#010101" fill-opacity=".3" textLength="330" transform="scale(.1)" x="795"
+            y="150">80.1%
+        </text>
+        <text textLength="330" transform="scale(.1)" x="795" y="140">80.1%</text>
     </g>
 </svg>

--- a/example/lib/screens/overview.dart
+++ b/example/lib/screens/overview.dart
@@ -20,9 +20,8 @@ class _OverviewScreenState extends State<OverviewScreen> {
         padding: const EdgeInsets.symmetric(
           horizontal: Dimens.paddingMedium20,
         ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
+        child: ListView(
+          padding: const EdgeInsets.symmetric(vertical: Dimens.paddingMedium),
           children: [
             BasfTextButton.contained(
               text: 'BASF Alerts',

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.8"
+    version: "2.1.9"
   characters:
     dependency: transitive
     description:

--- a/lib/src/widgets/buttons/basf_button.dart
+++ b/lib/src/widgets/buttons/basf_button.dart
@@ -1,3 +1,4 @@
+import 'package:basf_flutter_components/basf_flutter_components.dart';
 import 'package:flutter/material.dart';
 
 /// BASF button types
@@ -64,16 +65,20 @@ abstract class BasfButton extends StatelessWidget {
 
   /// Button content
   Widget buttonStandardContent() {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      mainAxisSize: expanded ? MainAxisSize.max : MainAxisSize.min,
-      children: [
-        if (leadingIcon != null) icon(leadingIcon!),
-        if (leadingIcon != null && text != null) const SizedBox(width: 12),
-        if (text != null) buttonText(),
-        if (trailingIcon != null && text != null) const SizedBox(width: 12),
-        if (trailingIcon != null) icon(trailingIcon!),
-      ],
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 48),
+      child: IntrinsicHeight(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          textBaseline: TextBaseline.ideographic,
+          mainAxisSize: expanded ? MainAxisSize.max : MainAxisSize.min,
+          children: [
+            if (leadingIcon != null) icon(leadingIcon!),
+            if (text != null) buttonText(),
+            if (trailingIcon != null) icon(trailingIcon!),
+          ].joinWithSeparator(const SizedBox(width: 12)),
+        ),
+      ),
     );
   }
 
@@ -103,9 +108,7 @@ abstract class BasfButton extends StatelessWidget {
 
   /// Icon
   Widget icon(IconData iconData) {
-    return Center(
-      child: Icon(iconData, size: iconSize ?? 19),
-    );
+    return FittedBox(child: Icon(iconData, size: iconSize ?? 19));
   }
 
   /// Style adjustments

--- a/lib/src/widgets/options/dropdown_input.dart
+++ b/lib/src/widgets/options/dropdown_input.dart
@@ -16,6 +16,7 @@ class BasfDropDownInput extends StatefulWidget {
     this.isExpanded = false,
     this.isLoading = false,
     this.isDisabled = false,
+    this.isMandatory = false,
   });
 
   /// Controller
@@ -41,6 +42,10 @@ class BasfDropDownInput extends StatefulWidget {
 
   /// Blocks dropdown and colors in grey
   final bool isDisabled;
+
+  /// Whether or not the border is displayed in current theme's error color
+  /// (e.g. red) if the field is empty
+  final bool isMandatory;
 
   @override
   State<BasfDropDownInput> createState() => _BasfDropDownInputState();
@@ -134,8 +139,13 @@ class _BasfDropDownInputState extends State<BasfDropDownInput> {
         border: Border.all(
           color: isDisabled
               ? disabledTheme
-                  .inputDecorationTheme.disabledBorder!.borderSide.color
-              : theme.inputDecorationTheme.enabledBorder!.borderSide.color,
+                      .inputDecorationTheme.disabledBorder?.borderSide.color ??
+                  theme.disabledColor
+              : widget.isMandatory && widget.controller.text.trim().isEmpty
+                  ? theme.errorColor
+                  : theme.inputDecorationTheme.enabledBorder?.borderSide
+                          .color ??
+                      theme.primaryColor,
         ),
       ),
       child: Row(
@@ -188,11 +198,14 @@ class _BasfDropDownInputState extends State<BasfDropDownInput> {
         size: 16,
         color: isDisabled
             ? BasfInputThemes.disabledInputTheme(theme)
-                .inputDecorationTheme
-                .disabledBorder!
-                .borderSide
-                .color
-            : theme.primaryColor,
+                    .inputDecorationTheme
+                    .disabledBorder
+                    ?.borderSide
+                    .color ??
+                theme.disabledColor
+            : widget.isMandatory && widget.controller.text.trim().isEmpty
+                ? theme.errorColor
+                : theme.primaryColor,
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: basf_flutter_components
 description: A collection of BASF Style components such as Buttons, Theming, etc...
-version: 2.1.8
+version: 2.1.9
 
 homepage: https://github.com/BASF-Mobile-Solutions/basf_flutter_components
 repository: https://github.com/BASF-Mobile-Solutions/basf_flutter_components

--- a/test/src/widgets/spacers_test.dart
+++ b/test/src/widgets/spacers_test.dart
@@ -1,12 +1,11 @@
-// import 'package:basf_flutter_components/basf_flutter_components.dart';
-// import 'package:flutter/material.dart';
-// import 'package:flutter_test/flutter_test.dart';
-//
-// import '../../helpers/pump_app.dart';
-// import '../../helpers/test_helpers.dart';
+import 'package:basf_flutter_components/basf_flutter_components.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/pump_app.dart';
+import '../../helpers/test_helpers.dart';
 
 void main() {
-  /*
   group('Paddings', () {
     testWidgets(
       'Vetical Spacer',
@@ -93,5 +92,4 @@ void main() {
       );
     });
   });
-  */
 }


### PR DESCRIPTION




## Description

- Added isMandatory param to DropDownInput. If it is set to true, and controller.text value is empty the border color is set to current theme's errorColor (default: false)

- Added limit of standard BasfButton height

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
